### PR TITLE
fix: use build_dependencies for build backend

### DIFF
--- a/neorg-se-scm-1.rockspec
+++ b/neorg-se-scm-1.rockspec
@@ -23,8 +23,11 @@ end
 dependencies = {
     "neorg ~> 8",
     "lua >= 5.1",
-    "luarocks-build-rust-mlua",
     "telescope.nvim",
+}
+
+build_dependencies = {
+  "luarocks-build-rust-mlua",
 }
 
 build = {


### PR DESCRIPTION
With the rockspec 3.0 format, build backends should be specified in the `build_dependencies`, not the `dependencies`

See also: https://github.com/folke/lazy.nvim/issues/1658